### PR TITLE
Update http compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,6 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 
 [compat]
-HTTP = "0.9"
+HTTP = "0.9, 1"
 JSON = "0.21"
 julia = "1"


### PR DESCRIPTION
Several bugs have been fixed between HTTP 0.9 and HTTP 1.

We have been using this branch for a bit and are confident it is non-breaking. Could you merge and release a version with HTTP 1?